### PR TITLE
Resolve 1 mismatch stubbings in AssignDriverObjectTest.java

### DIFF
--- a/src/test/java/com/lazerycode/selenium/util/SecondAssignDriverObjectTest.java
+++ b/src/test/java/com/lazerycode/selenium/util/SecondAssignDriverObjectTest.java
@@ -26,7 +26,7 @@ public class SecondAssignDriverObjectTest {
     public SecondAssignDriverObjectTest() {
         Capabilities mockedRemoteWebDriverCapabilities = mock(Capabilities.class);
         when(mockedRemoteWebDriverCapabilities.getBrowserName()).thenReturn(BrowserType.GOOGLECHROME);
-        when(mockedRemoteWebDriverCapabilities.getCapability("automationName")).thenReturn(null);
+        when(mockedRemoteWebDriverCapabilities.getCapability("automationName")).thenReturn(Platform.YOSEMITE);
         when(MOCKED_CHROME_DRIVER.getCapabilities()).thenReturn(mockedRemoteWebDriverCapabilities);
 
         Capabilities mockedAppiumDriverCapabilities = mock(Capabilities.class);

--- a/src/test/java/com/lazerycode/selenium/util/SecondAssignDriverObjectTest.java
+++ b/src/test/java/com/lazerycode/selenium/util/SecondAssignDriverObjectTest.java
@@ -16,17 +16,17 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.openqa.selenium.remote.CapabilityType.PLATFORM_NAME;
 
-public class AssignDriverObjectTest {
+public class SecondAssignDriverObjectTest {
     private static final RemoteWebDriver MOCKED_CHROME_DRIVER = mock(ChromeDriver.class);
     private static final AppiumDriver MOCKED_APPIUM_DRIVER = mock(AppiumDriver.class);
 
     private Query valid;
     private Query empty;
 
-    public AssignDriverObjectTest() {
+    public SecondAssignDriverObjectTest() {
         Capabilities mockedRemoteWebDriverCapabilities = mock(Capabilities.class);
         when(mockedRemoteWebDriverCapabilities.getBrowserName()).thenReturn(BrowserType.GOOGLECHROME);
-        when(mockedRemoteWebDriverCapabilities.getCapability(PLATFORM_NAME)).thenReturn(Platform.YOSEMITE);
+        when(mockedRemoteWebDriverCapabilities.getCapability("automationName")).thenReturn(null);
         when(MOCKED_CHROME_DRIVER.getCapabilities()).thenReturn(mockedRemoteWebDriverCapabilities);
 
         Capabilities mockedAppiumDriverCapabilities = mock(Capabilities.class);
@@ -37,15 +37,28 @@ public class AssignDriverObjectTest {
     }
 
     @Test
-    public void assignAppiumDriver() {
-        valid = new Query().defaultLocator(By.id("bar"));
+    public void assignRemoteWebDriver() {
+        valid = new Query().defaultLocator(By.id("foo"));
         empty = null;
 
         assertThat(valid.driverIsSet()).isFalse();
 
-        initQueryObjects(this, MOCKED_APPIUM_DRIVER);
+        initQueryObjects(this, MOCKED_CHROME_DRIVER);
 
         assertThat(empty).isNull();
         assertThat(valid.driverIsSet()).isTrue();
+    }
+    
+    @Test
+    public void assignDriverToClass() {
+        SomePageObject somePageObject = new SomePageObject();
+
+        assertThat(somePageObject.element.driverIsSet()).isFalse();
+        assertThat(somePageObject.anotherElement.driverIsSet()).isFalse();
+
+        initQueryObjects(somePageObject, MOCKED_CHROME_DRIVER);
+
+        assertThat(somePageObject.element.driverIsSet()).isTrue();
+        assertThat(somePageObject.anotherElement.driverIsSet()).isTrue();
     }
 }


### PR DESCRIPTION
We are researchers and analyzed the test doubles (mocks) in the test code of the project. In our analysis of the project, we observed that

1 stubbing which stubbed `getCapability` method are created in `AssignDriverObjectTest.AssignDriverObjectTest()`, was stubbed with argument "platformName", but in actual execution, it was called with argument "automationName", resulting in mismatched stubbings.  This mismatch occurs in tests `assignRemoteWebDriver` and `assignDriverToClass`.

Mismatched stubbing occurs when a mocked method is stubbed with specific arguments in a test but later invoked with different arguments in the code, potentially causing unexpected behavior. Mockito recommends addressing these issues, (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/PotentialStubbingProblem.html).

We propose a solution below to resolve the mismatch stubbings.
